### PR TITLE
feat(nvim): add claude code integration

### DIFF
--- a/config/claude/commands/commit.md
+++ b/config/claude/commands/commit.md
@@ -5,7 +5,7 @@ description: Create a git commit
 
 # Create a Git Commit
 
-Generate an English commit message following the Conventional Commits specification, then automatically run git commit -F with the generated message (no STDIN piping to avoid extra characters).
+Generate an English commit message following the Conventional Commits specification.
 
 ## Rules
 

--- a/config/claude/commands/commit.md
+++ b/config/claude/commands/commit.md
@@ -1,0 +1,27 @@
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+description: Create a git commit
+---
+
+# Create a Git Commit
+
+Generate an English commit message following the Conventional Commits specification, then automatically run git commit -F with the generated message (no STDIN piping to avoid extra characters).
+
+## Rules
+
+- Types: `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+- Subject: imperative, lowercase, ≤72 chars, no period.
+- Scope: optional; inferred from changed directory or provided.
+- Include concise bullets describing key changes.
+
+## Example
+
+```
+feat: add OAuth2 login
+
+Add OAuth2 authorization code flow with PKCE.
+
+- add login and callback routes
+- implement PKCE challenge/verify
+- store tokens securely in httpOnly cookies
+```

--- a/config/claude/commands/create-pr.md
+++ b/config/claude/commands/create-pr.md
@@ -1,0 +1,35 @@
+---
+
+allowed-tools: Bash(gh pr create:*), Bash(git push:*), Bash(git log:*), Bash(git rev-parse:*)
+description: Create a GitHub pull request via gh
+---
+
+# Create a GitHub Pull Request
+
+Use the GitHub CLI (`gh`) to create a pull request from the current branch.
+
+## Steps
+
+1. Determine the current branch name and ensure it’s pushed to origin.
+2. If a `.github/PULL_REQUEST_TEMPLATE.md` (or similar) exists, use it for the PR body.
+3. If no template is found, summarize the recent commits on this branch:
+  - Use the latest Conventional Commit–style commit message as the PR title.
+  - Generate a short English summary (1–2 sentences) and bullet list of changes for the body.
+4. Run:
+   ```bash
+   gh pr create --title "<conventional commit title>" --body "<summary and bullets>"
+   ```
+5. Confirm that the PR is created successfully and open it in the browser if desired.
+
+## Example
+
+```
+Title: feat(ui): add dark mode toggle
+
+Body:
+Add a dark mode toggle for the main interface.
+
+- add toggle button to header
+- store preference in localStorage
+- update styles for dark theme
+```

--- a/config/gitconfig
+++ b/config/gitconfig
@@ -10,8 +10,3 @@
 
 [core]
   editor = nvim
-
-[pager]
-  log = bat --paging=always
-  show = bat --paging=always
-  diff = bat --paging=always

--- a/config/lazy_nvim/lazy-lock.json
+++ b/config/lazy_nvim/lazy-lock.json
@@ -1,5 +1,6 @@
 {
   "Comment.nvim": { "branch": "master", "commit": "e30b7f2008e52442154b66f7c519bfd2f1e32acb" },
+  "claudecode.nvim": { "branch": "main", "commit": "ac2baef386d8078ef2a0aaa98580d25ec178f40a" },
   "cmp-buffer": { "branch": "main", "commit": "b74fab3656eea9de20a9b8116afa3cfc4ec09657" },
   "cmp-calc": { "branch": "main", "commit": "5947b412da67306c5b68698a02a846760059be2e" },
   "cmp-cmdline": { "branch": "main", "commit": "d126061b624e0af6c3a556428712dd4d4194ec6d" },
@@ -33,7 +34,7 @@
   "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
   "nvim-web-devicons": { "branch": "master", "commit": "6e51ca170563330e063720449c21f43e27ca0bc1" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
-  "rust-tools.nvim": { "branch": "master", "commit": "676187908a1ce35ffcd727c654ed68d851299d3e" },
+  "snacks.nvim": { "branch": "main", "commit": "aaab014bc6094514cfd3fae1d3bae92b8f91d519" },
   "toggleterm.nvim": { "branch": "main", "commit": "50ea089fc548917cc3cc16b46a8211833b9e3c7c" },
   "vim-vsnip": { "branch": "master", "commit": "0a4b8419e44f47c57eec4c90df17567ad4b1b36e" },
   "vim-vsnip-integ": { "branch": "master", "commit": "c7c93934dece8315db3649bdc6898b76358a8b8d" }

--- a/config/lazy_nvim/lua/plugins/claudecode.lua
+++ b/config/lazy_nvim/lua/plugins/claudecode.lua
@@ -1,0 +1,23 @@
+return {
+  "coder/claudecode.nvim",
+  dependencies = { "folke/snacks.nvim" },
+  config = true,
+  keys = {
+    { "<leader>ac", "<cmd>ClaudeCode<cr>",            desc = "Toggle Claude" },
+    { "<leader>af", "<cmd>ClaudeCodeFocus<cr>",       desc = "Focus Claude" },
+    { "<leader>ar", "<cmd>ClaudeCode --resume<cr>",   desc = "Resume Claude" },
+    { "<leader>aC", "<cmd>ClaudeCode --continue<cr>", desc = "Continue Claude" },
+    { "<leader>am", "<cmd>ClaudeCodeSelectModel<cr>", desc = "Select Claude model" },
+    { "<leader>ab", "<cmd>ClaudeCodeAdd %<cr>",       desc = "Add current buffer" },
+    { "<leader>as", "<cmd>ClaudeCodeSend<cr>",        mode = "v",                  desc = "Send to Claude" },
+    {
+      "<leader>as",
+      "<cmd>ClaudeCodeTreeAdd<cr>",
+      desc = "Add file",
+      ft = { "NvimTree", "neo-tree", "oil", "minifiles", "netrw" },
+    },
+    -- Diff management
+    { "<leader>aa", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" },
+    { "<leader>ad", "<cmd>ClaudeCodeDiffDeny<cr>",   desc = "Deny diff" },
+  },
+}

--- a/config/zsh/alias.zsh
+++ b/config/zsh/alias.zsh
@@ -5,7 +5,7 @@ alias gb="git branch"
 alias gs="git status"
 alias gl="git log"
 alias grs="git reset --soft"
-alias gbd="git branch --merged main | grep -vE '^\*|main$' | xargs -I % git branch -d %"
+alias gbd="git branch --merged main | grep -vE '^\*|main$|master$' | xargs -I % git branch -d %"
 alias glg="git log --oneline --graph --decorate"
 alias gps="git push"
 alias gpl="git pull"
@@ -27,11 +27,6 @@ fi
 # npm
 alias envinfo='npx envinfo'
 alias uuid='npx uuid'
-
-# bat
-if [[ $(command -v bat) ]]; then
-  alias cat='bat --color=always'
-fi
 
 # exa
 if [[ $(command -v eza) ]]; then


### PR DESCRIPTION
Add Claude Code plugin for Neovim with custom slash command and refactor configuration.

- add claudecode.nvim plugin with keybindings
- add snacks.nvim dependency
- create /commit slash command for conventional commits
- update lazy-lock.json with new plugins
- remove bat pager settings from gitconfig
- remove bat cat alias from zsh config
- update gbd alias to exclude master branch